### PR TITLE
Add a better Lecture Recording catalog

### DIFF
--- a/src/menu/quicklinksMenu.html
+++ b/src/menu/quicklinksMenu.html
@@ -73,7 +73,7 @@
 						<a href="https://www.mcgill.ca/study" target="_blank" rel="noopener noreferrer" class="btn btn-default meButton">
 							McGill eCalendar
 						</a>
-						<a href="http://lrs.mcgill.ca" target="_blank" rel="noopener noreferrer" class="btn btn-default meButton">
+						<a href="https://jhcccc.github.io/LRSPlus/" target="_blank" rel="noopener noreferrer" class="btn btn-default meButton">
 							Lecture Recordings
 						</a>
 						<a href="https://vsb.mcgill.ca/vsb/criteria.jsp" target="_blank" rel="noopener noreferrer" class="btn btn-default meButton">


### PR DESCRIPTION
Hello Demetrios, 

I made an [unofficial lecture recording catalog](https://jhcccc.github.io/LRSPlus/). I hope that this may help McGill students better find recordings or exploring the recordings list. I'd really appreciate if you could consider putting it in the quicklink menu.

P.S. I just noticed that you are also working on a LRS list scraping feature to show recording link in e-calendar side bar. That's sweet!