### PR TITLE
Feature: download lecture

### DIFF
--- a/runbuild.sh
+++ b/runbuild.sh
@@ -74,7 +74,7 @@ for platform in "$@"; do
 		sed -i '/"persistent"/d' $file  
 		match='"background": {'
 		insertA='    "persistent": true,'  
-		insertB='    "page": "background.html",'  
+		#insertB='    "page": "background.html",'  
 		sed -i "s/$match/$match\n$insertA/" $file
 		#sed -i "s/$match/$match\n$insertB/" $file
 

--- a/runbuild.sh
+++ b/runbuild.sh
@@ -70,13 +70,13 @@ for platform in "$@"; do
 		insert='  "-ms-preload":{"backgroundScript":"backgroundScriptsAPIBridge.js","contentScript":"contentScriptsAPIBridge.js"},'  
 		sed -i "s/$match/$match\n$insert/" $file
 
-		sed -i '/"scripts"/d' $file  
+		#sed -i '/"scripts"/d' $file  
 		sed -i '/"persistent"/d' $file  
 		match='"background": {'
-		insertA='    "persistent": true'  
+		insertA='    "persistent": true,'  
 		insertB='    "page": "background.html",'  
 		sed -i "s/$match/$match\n$insertA/" $file
-		sed -i "s/$match/$match\n$insertB/" $file
+		#sed -i "s/$match/$match\n$insertB/" $file
 
 	fi
 

--- a/src/js/xhr.js
+++ b/src/js/xhr.js
@@ -1,7 +1,14 @@
+/* script to listen to network requests.
+   The url captured contains the download link.
+   Every mcgill lecture download link starts with pcdn (pcdn01, pcdn02, ...)
+  */
 chrome.webRequest.onCompleted.addListener(function(details) {
   
     if (details.url.search("pcdn") != -1) {
       chrome.storage.sync.set({lecture: details.url}, function() {
+        // The url is saved to storage and persists across sessions
+        // ie. if you close the window and boot up again it will still be there.
+        // if that is not desirable, could always clear at startup
         console.log("New url saved to lecture");
       });
   

--- a/src/js/xhr.js
+++ b/src/js/xhr.js
@@ -4,12 +4,12 @@
   */
 chrome.webRequest.onCompleted.addListener(function(details) {
   
-    if (details.url.search("pcdn") != -1) {
+    if (details.url.search('pcdn') !== -1) {
       chrome.storage.sync.set({lecture: details.url}, function() {
         // The url is saved to storage and persists across sessions
         // ie. if you close the window and boot up again it will still be there.
         // if that is not desirable, could always clear at startup
-        console.log("New url saved to lecture");
+        //console.log("New url saved to lecture");
       });
   
     }

--- a/src/js/xhr.js
+++ b/src/js/xhr.js
@@ -7,7 +7,7 @@ chrome.webRequest.onCompleted.addListener(function(details) {
   
     if (new URL(details.url).hostname.startsWith('pcdn')) {
         chrome.storage.sync.get('lecture', function(data) {
-          if (details.url != data.lecture) {
+          if (details.url !== data.lecture) {
             chrome.storage.sync.set({lecture: details.url}, function() {
               //console.log('New url saved to lecture');
             });

--- a/src/js/xhr.js
+++ b/src/js/xhr.js
@@ -1,0 +1,10 @@
+chrome.webRequest.onCompleted.addListener(function(details) {
+  
+    if (details.url.search("pcdn") != -1) {
+      chrome.storage.sync.set({lecture: details.url}, function() {
+        console.log("New url saved to lecture");
+      });
+  
+    }
+  
+  }, {urls: ['*://*.mcgill.ca/*']});

--- a/src/js/xhr.js
+++ b/src/js/xhr.js
@@ -2,16 +2,17 @@
    The url captured contains the download link.
    Every mcgill lecture download link starts with pcdn (pcdn01, pcdn02, ...)
   */
+
 chrome.webRequest.onCompleted.addListener(function(details) {
   
-    if (details.url.search('pcdn') !== -1) {
-      chrome.storage.sync.set({lecture: details.url}, function() {
-        // The url is saved to storage and persists across sessions
-        // ie. if you close the window and boot up again it will still be there.
-        // if that is not desirable, could always clear at startup
-        //console.log("New url saved to lecture");
+    if (new URL(details.url).hostname.startsWith('pcdn')) {
+        chrome.storage.sync.get('lecture', function(data) {
+          if (details.url != data.lecture) {
+            chrome.storage.sync.set({lecture: details.url}, function() {
+              //console.log('New url saved to lecture');
+            });
+          }
       });
-  
     }
-  
-  }, {urls: ['*://*.mcgill.ca/*']});
+
+  }, {urls: ['*://*.campus.mcgill.ca/api/tsmedia*']});

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,7 +9,8 @@
     "*://*.mcgill.ca/*",
     "*://demetrios-koziris.github.io/*",
     "*://www.docuum.com/*",
-    "webRequest"
+    "webRequest",
+    "downloads"
   ],
   "background": {
     "scripts": [

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,7 +9,9 @@
     "*://*.mcgill.ca/*",
     "*://demetrios-koziris.github.io/*",
     "*://www.docuum.com/*",
-    "webRequest",
+    "webRequest"
+  ],
+  "optional_permissions": [
     "downloads"
   ],
   "background": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -8,12 +8,14 @@
     "storage",
     "*://*.mcgill.ca/*",
     "*://demetrios-koziris.github.io/*",
-    "*://www.docuum.com/*"
+    "*://www.docuum.com/*",
+    "webRequest"
   ],
   "background": {
     "scripts": [
       "js/backgroundHTTP.js",
-      "js/background.js"
+      "js/background.js",
+      "js/xhr.js"
     ]
   },
   "browser_action": {

--- a/src/menu/quicklinksMenu.html
+++ b/src/menu/quicklinksMenu.html
@@ -82,6 +82,10 @@
 						<a href="https://onecard.mcgill.ca/" target="_blank" rel="noopener noreferrer" class="btn btn-default meButton">
 							OneCard & Meal Plan
 						</a>
+
+						<a target="_blank" rel="noopener noreferrer" class="btn btn-default meButton"
+							id="downloadLec"> Download most recent lecture
+						</a>
 					</td>
 				</tr>
 			</table>

--- a/src/menu/quicklinksMenu.html
+++ b/src/menu/quicklinksMenu.html
@@ -35,6 +35,9 @@
 						<a href="http://www.docuum.com/McGill" target="_blank" rel="noopener noreferrer" class="btn btn-default meButton docuumButton">
 							Docuum
 						</a>
+						<a target="_blank" rel="noopener noreferrer" class="btn btn-default meButton"
+							id="downloadLec"> Download last viewed lecture
+						</a>
 						<h4 class="meTitle">
 							Online Community
 						</h4>
@@ -83,9 +86,7 @@
 							OneCard & Meal Plan
 						</a>
 
-						<a target="_blank" rel="noopener noreferrer" class="btn btn-default meButton"
-							id="downloadLec"> Download last viewed lecture
-						</a>
+						
 					</td>
 				</tr>
 			</table>

--- a/src/menu/quicklinksMenu.html
+++ b/src/menu/quicklinksMenu.html
@@ -84,7 +84,7 @@
 						</a>
 
 						<a target="_blank" rel="noopener noreferrer" class="btn btn-default meButton"
-							id="downloadLec"> Download most recent lecture
+							id="downloadLec"> Download last viewed lecture
 						</a>
 					</td>
 				</tr>

--- a/src/menu/quicklinksMenu.js
+++ b/src/menu/quicklinksMenu.js
@@ -65,12 +65,12 @@ downloadLec.onclick = function() {
 				if (granted) {
 					chrome.downloads.download({
 						url: data.lecture,
-						filename: "last-viewed-lecture-recording.mp4",
+						filename: 'last-viewed-lecture-recording.mp4',
 						saveAs: true
-					})
+					});
 				} 
 				else {
-					alert('Download permission not granted.')
+					alert('Download permission not granted.');
 				}
 			});
 		}

--- a/src/menu/quicklinksMenu.js
+++ b/src/menu/quicklinksMenu.js
@@ -61,10 +61,17 @@ initializeEnabledSwitch();
 downloadLec.onclick = function() {
 	chrome.storage.sync.get('lecture', function(data) {
 		if (data.lecture) { // The download will not happen if the link is empty.
-			chrome.downloads.download({
-				url: data.lecture,
-				filename: 'lecture.mp4',
-				saveAs: true
+			chrome.permissions.request({permissions: ['downloads']}, function(granted) {
+				if (granted) {
+					chrome.downloads.download({
+						url: data.lecture,
+						filename: "last-viewed-lecture-recording.mp4",
+						saveAs: true
+					})
+				} 
+				else {
+					alert('Download permission not granted.')
+				}
 			});
 		}
 	});

--- a/src/menu/quicklinksMenu.js
+++ b/src/menu/quicklinksMenu.js
@@ -21,7 +21,7 @@ const isPROD = prodIDs.includes(chrome.runtime.id);
 const isINT = intIDs.includes(chrome.runtime.id);
 const versionString = chrome.runtime.getManifest().version + (isPROD ? '' : (isINT ? ' INT' : ' DEV') + ' (' + chrome.runtime.id.substring(0, 6) + ')');
 
-let downloadLec = document.getElementById("downloadLec");
+let downloadLec = document.getElementById('downloadLec');
 
 
 document.getElementById('version').innerText += 'McGill Enhanced Version ' + versionString;
@@ -59,13 +59,13 @@ initializeEnabledSwitch();
 // Functionality for download lecture button.
 // Gets the url from storage and prompts a download.
 downloadLec.onclick = function() {
-	chrome.storage.sync.get("lecture", function(data) {
+	chrome.storage.sync.get('lecture', function(data) {
 		if (data.lecture) { // The download will not happen if the link is empty.
 			chrome.downloads.download({
 				url: data.lecture,
-				filename: "lecture.mp4",
+				filename: 'lecture.mp4',
 				saveAs: true
-			})
+			});
 		}
 	});
-}
+};

--- a/src/menu/quicklinksMenu.js
+++ b/src/menu/quicklinksMenu.js
@@ -21,6 +21,9 @@ const isPROD = prodIDs.includes(chrome.runtime.id);
 const isINT = intIDs.includes(chrome.runtime.id);
 const versionString = chrome.runtime.getManifest().version + (isPROD ? '' : (isINT ? ' INT' : ' DEV') + ' (' + chrome.runtime.id.substring(0, 6) + ')');
 
+let downloadLec = document.getElementById("downloadLec");
+
+
 document.getElementById('version').innerText += 'McGill Enhanced Version ' + versionString;
 
 document.getElementById('enabledSwitch').addEventListener('click', updateEnabledSetting);
@@ -52,3 +55,9 @@ function initializeEnabledSwitch() {
 	});
 }
 initializeEnabledSwitch();
+
+chrome.storage.sync.get("lecture", function(data) {
+	if (data.lecture) {
+		downloadLec.setAttribute("href", data.lecture);
+	}
+});

--- a/src/menu/quicklinksMenu.js
+++ b/src/menu/quicklinksMenu.js
@@ -56,8 +56,16 @@ function initializeEnabledSwitch() {
 }
 initializeEnabledSwitch();
 
-chrome.storage.sync.get("lecture", function(data) {
-	if (data.lecture) {
-		downloadLec.setAttribute("href", data.lecture);
-	}
-});
+// Functionality for download lecture button.
+// Gets the url from storage and prompts a download.
+downloadLec.onclick = function() {
+	chrome.storage.sync.get("lecture", function(data) {
+		if (data.lecture) { // The download will not happen if the link is empty.
+			chrome.downloads.download({
+				url: data.lecture,
+				filename: "lecture.mp4",
+				saveAs: true
+			})
+		}
+	});
+}


### PR DESCRIPTION
# Context
I have seen multiple posts on some social media about how students would like to download lectures not normally available for download (most recently [here](https://www.reddit.com/r/mcgill/comments/hamvzl/is_there_any_way_to_download_lectures_when/), but also [here](https://www.reddit.com/r/mcgill/comments/2mu17j/downloading_lecture_recordings/), [here](https://www.reddit.com/r/mcgill/comments/e22jyi/downloading_lecture_recordings/) and more).

I assume, then, that there is a sizeable amount of people who would find it beneficial to have a simple way to download inaccessible recordings, especially during these times where *everything* is basically remote teaching.

Because of this, I propose that McGill Enhanced should offer a feature to download the last viewed lecture by the user. The purpose is to be able to get recordings in situations where the professor has turned the option off (I don't think this is a "bad" thing to do, it only uses what is normally already available to the user through the developer tools).

# Additions
- download last viewed lecture button on quick links menu. Working on:
   - [x] Chrome 83
   - [x] Edge Chromium 83
   - [x] Firefox 77
      - **Usage**: go to a mcgill lecture recording (mycourses or lrs), click play. Then open the McGill Enhanced menu, click "Download last viewed lecture"
- a script that checks in the background for network requests on mcgill urls. Looks for domain "pcdn" to save the download url to chrome.storage
- permissions updated with what is necessary

# Fixes
- fix edge build in runbuild.sh (in manifest.json, it was not writing the "scripts" part correctly in "backgrounds")
   - tested on WSL Ubuntu 20.04, Linux Ubuntu 18.04
   - the legacy edge is being phased out and being completely replaced by chromium edge, so edge extensions should be compatible with the chrome equivalent ("-ms-preload" key is not necessary unless you still want to support the legacy browser)

