### PR TITLE
Update to the new MyMcgill link

### DIFF
--- a/src/menu/quicklinksMenu.html
+++ b/src/menu/quicklinksMenu.html
@@ -65,7 +65,7 @@
 							McGill Homepage
 						</a>
 						<a target="_blank" rel="noopener noreferrer" class="btn meButton"
-							href="https://mymcgill.mcgill.ca">
+							href="https://mcgill.ca/mymcgill">
 							MyMcgill
 						</a>
 						<a target="_blank" rel="noopener noreferrer" class="btn meButton"


### PR DESCRIPTION
Currently, when clicking the myMcgill link from the menu, the opened page just reads "myMcGill is now located here: https://mcgill.ca/mymcgill", so this would just go directly to that url.